### PR TITLE
fix: [10002874] fix representation of "\n" in details text

### DIFF
--- a/src/components/Presale/PassportDetails/PassportDetails.module.css
+++ b/src/components/Presale/PassportDetails/PassportDetails.module.css
@@ -19,6 +19,7 @@
 
 .itemDescription {
   color: var(--text-primary);
+  white-space: pre-line;
 }
 
 .listMark {


### PR DESCRIPTION
to remove setting styles from parent container through data-testid

<img width="1933" height="799" alt="chrome_XG8Y869maY" src="https://github.com/user-attachments/assets/34ef241e-0c88-4060-867a-0923bb8dd1d4" />

**BEFORE**:
<img width="1038" height="1040" alt="chrome_mHW5iO4vXp" src="https://github.com/user-attachments/assets/cd70d4f0-5d0f-4d36-b6cc-b7299f1d0675" />

**AFTER**
<img width="1035" height="1033" alt="chrome_bZIXz5ymp6" src="https://github.com/user-attachments/assets/41b1f18b-d0df-47ce-b221-69a5ad15c3e9" />
